### PR TITLE
linting and setup fixes

### DIFF
--- a/.runner
+++ b/.runner
@@ -26,7 +26,7 @@ have_riak_admin='false'
 if hash riak-admin 2>/dev/null
 then
     have_riak_admin='true'
-    $riak_admin='riak-admin'
+    riak_admin='riak-admin'
 else
     set +o nounset
 

--- a/commands.py
+++ b/commands.py
@@ -398,7 +398,7 @@ class build_messages(Command):
             # class RpbCounterGetResp(_message.Message):
             contents = re.sub(
                 r'class\s+(\S+)\((\S+)\):\s*\n'
-                '\s+__metaclass__\s+=\s+(\S+)\s*\n',
+                r'\s+__metaclass__\s+=\s+(\S+)\s*\n',
                 r'@add_metaclass(\3)\nclass \1(\2):\n', contents)
 
             with open(im, 'w', buffering=1) as pbfile:

--- a/riak/client/__init__.py
+++ b/riak/client/__init__.py
@@ -341,7 +341,7 @@ class RiakClient(RiakMapReduceChain, RiakClientOperations):
     def _create_node(self, n):
         if isinstance(n, RiakNode):
             return n
-        elif isinstance(n, tuple) and len(n) is 3:
+        elif isinstance(n, tuple) and len(n) == 3:
             host, http_port, pb_port = n
             return RiakNode(host=host,
                             http_port=http_port,
@@ -382,7 +382,7 @@ class RiakClient(RiakMapReduceChain, RiakClientOperations):
 
         good = [n for n in nodes if _error_rate(n) < 0.1]
 
-        if len(good) is 0:
+        if len(good) == 0:
             # Fall back to a minimally broken node
             return min(nodes, key=_error_rate)
         else:

--- a/riak/client/multi.py
+++ b/riak/client/multi.py
@@ -211,7 +211,7 @@ class MultiPutPool(MultiPool):
                 elif isinstance(obj, TsObject):
                     rv = task.client.ts_put(obj, **task.options)
                 else:
-                    raise ValueError('unknown obj type: %s'.format(type(obj)))
+                    raise ValueError('unknown obj type: {0}'.format(type(obj)))
                 task.outq.put(rv)
             except KeyboardInterrupt:
                 raise

--- a/riak/datatypes/counter.py
+++ b/riak/datatypes/counter.py
@@ -39,7 +39,7 @@ class Counter(Datatype):
         """
         Whether this counter has staged increments.
         """
-        return self._increment is not 0
+        return self._increment != 0
 
     def to_op(self):
         """

--- a/riak/datatypes/map.py
+++ b/riak/datatypes/map.py
@@ -282,7 +282,7 @@ class Map(Mapping, Datatype):
         for key in value:
             try:
                 self._check_key(key)
-            except:
+            except Exception:
                 return False
         return True
 

--- a/riak/mapreduce.py
+++ b/riak/mapreduce.py
@@ -358,7 +358,7 @@ class RiakMapReduce(object):
         num_phases = len(self._phases)
 
         # If there are no phases, return the keys as links
-        if num_phases is 0:
+        if num_phases == 0:
             link_results_flag = True
         else:
             link_results_flag = False

--- a/riak/tests/test_pool.py
+++ b/riak/tests/test_pool.py
@@ -115,7 +115,7 @@ class PoolTest(unittest.TestCase, Comparison):
             with pool.transaction():
                 with pool.transaction():
                     raise RuntimeError
-        except:
+        except Exception:
             self.assertEqual(2, len(pool.resources))
             for e in pool.resources:
                 self.assertFalse(e.claimed)

--- a/riak/tests/test_yokozuna.py
+++ b/riak/tests/test_yokozuna.py
@@ -170,7 +170,7 @@ class YZSearchTests(IntegrationTestBase, unittest.TestCase, Comparison):
         wait_for_yz_index(bucket, "H")
         # multiterm
         results = bucket.search("username_s:(F OR H)")
-        l = len(results['docs'])
+        l = len(results['docs'])        # noqa: E741
         self.assertTrue(l == 2 or l == 3)
         # boolean
         results = bucket.search("username_s:Z AND name_s:ryan")
@@ -186,7 +186,7 @@ class YZSearchTests(IntegrationTestBase, unittest.TestCase, Comparison):
         self.assertEqual(2, len(results['docs']))
         # regexp
         results = bucket.search('name_s:/br.*/')
-        l = len(results['docs'])
+        l = len(results['docs'])        # noqa: E741
         self.assertTrue(l == 2 or l == 3)
         # Parameters:
         # limit

--- a/riak/transports/security.py
+++ b/riak/transports/security.py
@@ -305,7 +305,7 @@ else:
                     try:
                         data = self._sock.recv(self._rbufsize)
                     except OpenSSL.SSL.WantReadError:
-                            continue
+                        continue
                     if not data:
                         break
                     left = size - buf_len

--- a/riak/transports/tcp/stream.py
+++ b/riak/transports/tcp/stream.py
@@ -51,7 +51,7 @@ class PbufStream(object):
             expect = self._expect
             self.codec.maybe_incorrect_code(resp_code, expect)
             resp = self.codec.parse_msg(expect, data)
-        except:
+        except Exception:
             self.finished = True
             raise
         finally:
@@ -96,7 +96,7 @@ class PbufKeyStream(PbufStream):
     def next(self):
         response = super(PbufKeyStream, self).next()
 
-        if response.done and len(response.keys) is 0:
+        if response.done and len(response.keys) == 0:
             raise StopIteration
 
         return response.keys
@@ -137,7 +137,7 @@ class PbufBucketStream(PbufStream):
     def next(self):
         response = super(PbufBucketStream, self).next()
 
-        if response.done and len(response.buckets) is 0:
+        if response.done and len(response.buckets) == 0:
             raise StopIteration
 
         return response.buckets
@@ -199,7 +199,7 @@ class PbufTsKeyStream(PbufStream, TtbCodec):
     def next(self):
         response = super(PbufTsKeyStream, self).next()
 
-        if response.done and len(response.keys) is 0:
+        if response.done and len(response.keys) == 0:
             raise StopIteration
 
         keys = []

--- a/riak/transports/transport.py
+++ b/riak/transports/transport.py
@@ -362,7 +362,7 @@ class Transport(FeatureDetection):
         return [key for resultbucket, key in result]
 
     def _construct_mapred_json(self, inputs, query, timeout=None):
-        if not self.phaseless_mapred() and (query is None or len(query) is 0):
+        if not self.phaseless_mapred() and (query is None or len(query) == 0):
             raise Exception(
                 'Phase-less MapReduce is not supported by Riak node')
 


### PR DESCRIPTION
This fixes issues I ran into running tests (via `make all`) using Python 3.8.5.

After these changes (+ some riak config, see below), all but three integration tests that run by default are succeeding. The failing tests are 

* `riak.tests.test_mapreduce` and `riak.tests.test_yokozuna`: Error is `Unknown message code: 56`. Looks like this may be because yokozuna uses Solr, which I haven't configured.
* `test_store_binary_object_from_file_should_use_default_mimetype (riak.tests.test_kv.KVFileTests)`: Guessing this may just be a difference in how different versions of Riak set MIME types. The MIME type is being set to `text/markdown` based on the file extension, but the test is expecting `application/octet-stream`.

Some notes on how I installed and configured Riak locally (Ubuntu 20.04) (very likely I've missed some steps here because there was a lot of trial and error):

```sh
# Install Riak dependencies
wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.6_amd64.deb
sudo dpkg -i libssl1.0.0_1.0.2n-1ubuntu5.6_amd64.deb
sudo apt install libtinfo5

# Install riak
wget http://files.edtd.net/riak_2.2.3-1_amd64.deb
sudo dpkg -i riak_2.2.3-1_amd64.deb

# Config updates:
# storage_backend = leveldb
# leveldb.maximum_memory.percent = 20  # was using too much memory
sudo vi /etc/riak/riak.conf

# Start riak
sudo /etc/init.d/riak start

# Add no_siblings bucket type
sudo riak-admin bucket-type create no_siblings '{"props":{"allow_mult":"false"}}'
sudo riak-admin bucket-type activate no_siblings

# Add no_siblings bucket type
sudo riak-admin bucket-type create write_once '{"props": {"write_once": true}}'
sudo riak-admin bucket-type activate write_once

# Add bucket types for data types
sudo riak-admin bucket-type create maps '{"props":{"datatype":"map"}}'
sudo riak-admin bucket-type create sets '{"props":{"datatype":"set"}}'
sudo riak-admin bucket-type create counters '{"props":{"datatype":"counter"}}'
sudo riak-admin bucket-type create hlls  '{"props":{"datatype":"hll"}}'
sudo riak-admin bucket-type activate maps
sudo riak-admin bucket-type activate sets
sudo riak-admin bucket-type activate counters
sudo riak-admin bucket-type activate hlls

# Install riak-python-client dependencies
pip install setuptools
pip install protobuf
pip install tox
sudo apt-get install protobuf-compiler
sudo apt-get install pandoc

# Run lint & tests
make all
```

